### PR TITLE
Fix mocha require path

### DIFF
--- a/test/test_xmpfilter.rb
+++ b/test/test_xmpfilter.rb
@@ -3,7 +3,7 @@ require 'test/unit'
 $: << ".." << "../lib"
 require "rcodetools/xmpfilter"
 require 'rubygems'
-require 'mocha'
+require 'mocha/test_unit'
 
 class TestXMPFilter < Test::Unit::TestCase
   include Rcodetools


### PR DESCRIPTION
This fixes test below.

```
.......E
======================================================================
Error: test_initialize__test_script_1(TestXMPFilter): NoMethodError: undefined method `any_instance' for Rcodetools::XMPFilter:Class
/home/aycabta/rcodetools/test/test_xmpfilter.rb:75:in `test_initialize__test_script_1'
     72:   end
     73:
     74:   def test_initialize__test_script_1
  => 75:     XMPFilter.any_instance.stubs(:safe_require_code).returns("require 'test/unit'")
     76:     xmp = XMPFilter.new(:test_script=>"/path/to/test/test_ruby_toggle_file.rb",
     77:                          :test_method=>"test_implementation_file_file_exist",
     78:                          :filename=>"/path/to/lib/ruby_toggle_file.rb")
======================================================================
E
======================================================================
Error: test_initialize__test_script_2(TestXMPFilter): NoMethodError: undefined method `any_instance' for Rcodetools::XMPFilter:Class
/home/aycabta/rcodetools/test/test_xmpfilter.rb:90:in `test_initialize__test_script_2'
     87:   end
     88:
     89:   def test_initialize__test_script_2
  => 90:     XMPFilter.any_instance.stubs(:safe_require_code).returns("require 'test/unit'")
     91:     xmp = XMPFilter.new(:test_script=>"/path/to/test_ruby_toggle_file.rb",
     92:                          :test_method=>"test_implementation_file_file_exist",
     93:                          :filename=>"/path/to/ruby_toggle_file.rb")
======================================================================
E
======================================================================
Error: test_initialize__test_script_3(TestXMPFilter): NoMethodError: undefined method `any_instance' for Rcodetools::XMPFilter:Class
/home/aycabta/rcodetools/test/test_xmpfilter.rb:107:in `test_initialize__test_script_3'
     104:   def test_initialize__test_script_3
     105:     test_script = File.join(File.dirname(__FILE__), "data/sample_test_script.rb")
     106:     filename = File.join(File.dirname(__FILE__), "data/sample.rb")
  => 107:     XMPFilter.any_instance.stubs(:safe_require_code).returns("require 'test/unit'")
     108:     xmp = XMPFilter.new(:test_script=>test_script, :test_method=>"4", :filename=>filename)
     109:
     110:     evals_expected = [
======================================================================
..E
======================================================================
Error: test_interpreter_command_detect_rct_fork(TestXMPFilter): NoMethodError: undefined method `stubs' for Rcodetools::Fork:Module
/home/aycabta/rcodetools/test/test_xmpfilter.rb:64:in `test_interpreter_command_detect_rct_fork'
     61:   end
     62:
     63:   def test_interpreter_command_detect_rct_fork
  => 64:     Fork.stubs(:run?).returns true
     65:     xmp = XMPFilter.new(:interpreter=>"ruby", :detect_rct_fork => true)
     66:     assert_equal(%w[ruby -S rct-fork-client], xmp.interpreter_command)
     67:   end
======================================================================
```