### PR TITLE
Namespace relocation

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,10 +9,9 @@ task :coverage do
 end
 
 $:.unshift "lib" if File.directory? "lib"
-require 'rcodetools/xmpfilter'
+require 'rcodetools'
 require 'rake/testtask'
-include Rcodetools
-RCT_VERSION  = XMPFilter::VERSION
+RCT_VERSION  = Rcodetools::VERSION
 
 desc "Run the unit tests in pure-Ruby mode ."
 Rake::TestTask.new(:test) do |t|

--- a/lib/rcodetools.rb
+++ b/lib/rcodetools.rb
@@ -1,0 +1,5 @@
+require 'rcodetools/version'
+require 'rcodetools/xmpfilter'
+
+module Rcodetools
+end

--- a/lib/rcodetools/version.rb
+++ b/lib/rcodetools/version.rb
@@ -1,0 +1,3 @@
+module Rcodetools
+  VERSION = "0.8.5"
+end

--- a/lib/rcodetools/xmpfilter.rb
+++ b/lib/rcodetools/xmpfilter.rb
@@ -15,8 +15,6 @@ require 'tmpdir'
 module Rcodetools
 
 class XMPFilter
-  VERSION = "0.8.5"
-
   MARKER = "!XMP#{Time.new.to_i}_#{Process.pid}_#{rand(1000000)}!"
   XMP_RE = Regexp.new("^" + Regexp.escape(MARKER) + '\[([0-9]+)\] (=>|~>|==>) (.*)')
   VAR = "_xmp_#{Time.new.to_i}_#{Process.pid}_#{rand(1000000)}"


### PR DESCRIPTION
- all it takes is a `require 'rcodetools'` instead of `require 'rcodetools/xmpfilter'`
- use `Rcodetools::VERSION` instead of `Rcodetools::XMPFilter::VERSION`