### PR TITLE
Fix gem build error

### DIFF
--- a/rcodetools.gemspec
+++ b/rcodetools.gemspec
@@ -31,8 +31,8 @@ EOF
   spec.require_paths = ["lib"]
 
   spec.has_rdoc = true
-  spec.extra_rdoc_files = %w[README]
-  spec.rdoc_options << "--main" << "README" << "--title" << 'rcodetools'
+  spec.extra_rdoc_files = %w[README.md]
+  spec.rdoc_options << "--main" << "README.md" << "--title" << 'rcodetools'
   spec.test_files = Dir["test/test_*.rb"]
   spec.post_install_message = <<EOF
 


### PR DESCRIPTION
before:

    $ gem build rcodetools.gemspec
    WARNING:  See http://guides.rubygems.org/specification-reference/ for help
    ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
        ["README"] are not files

after:

    $ gem build rcodetools.gemspec
    WARNING:  license value '' is invalid.  Use a license identifier from
    http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
    WARNING:  See http://guides.rubygems.org/specification-reference/ for help
    Successfully built RubyGem
    Name: rcodetools
    Version: 0.8.5
    File: rcodetools-0.8.5.gem